### PR TITLE
Add support for depth of obstacles 

### DIFF
--- a/ev3dev2simulator/obstacle/hole.py
+++ b/ev3dev2simulator/obstacle/hole.py
@@ -17,10 +17,12 @@ class Hole:
     def __init__(self,
                  x: int,
                  y: int,
-                 radius: float):
+                 radius: float,
+                 depth: float):
         self.x = x
         self.y = y
         self.radius = radius
+        self.depth = depth
 
         # visualisation
         self.points = None

--- a/ev3dev2simulator/obstacle/lake.py
+++ b/ev3dev2simulator/obstacle/lake.py
@@ -23,7 +23,8 @@ class Lake(ColorObstacle):
                  inner_radius: float,
                  color: arcade.Color,
                  border_width: int,
-                 has_hole: bool):
+                 has_hole: bool,
+                 depth: float):
         super(Lake, self).__init__(to_color_code(color))
 
         self.x = pos.x
@@ -33,7 +34,7 @@ class Lake(ColorObstacle):
         self.inner_radius = inner_radius
         self.hole = None
         if has_hole:
-            self.hole = self._create_hole()
+            self.hole = self._create_hole(depth)
         self.outer_radius = outer_radius
 
         # visualisation
@@ -71,10 +72,11 @@ class Lake(ColorObstacle):
 
         pos = Point(config['x'], config['y'])
         has_hole = config['hole'] if 'hole' in config else True
+        depth = config['depth'] if 'depth' in config else 800
 
         color = tuple(config['color'])
 
-        return cls(pos, outer_radius, inner_radius, color, border_width, has_hole)
+        return cls(pos, outer_radius, inner_radius, color, border_width, has_hole, depth)
 
     def _create_points(self, scale) -> PointList:
         """
@@ -99,11 +101,11 @@ class Lake(ColorObstacle):
         return create_ellipse_filled(self.center_x, self.center_y,
                                      self.outer_radius * scale, self.outer_radius * scale, self.color)
 
-    def _create_hole(self):
+    def _create_hole(self, depth):
         """
         Create hole object in lake that is used for detection that the robot is stuck.
         """
-        return Hole(self.x, self.y, self.inner_radius)
+        return Hole(self.x, self.y, self.inner_radius, depth)
 
     def collided_with(self, x: float, y: float) -> bool:
         """

--- a/ev3dev2simulator/obstacle/lake.py
+++ b/ev3dev2simulator/obstacle/lake.py
@@ -23,8 +23,8 @@ class Lake(ColorObstacle):
                  inner_radius: float,
                  color: arcade.Color,
                  border_width: int,
-                 has_hole: bool,
-                 depth: float):
+                 hole_config: (bool, int)
+                 ):
         super(Lake, self).__init__(to_color_code(color))
 
         self.x = pos.x
@@ -33,8 +33,10 @@ class Lake(ColorObstacle):
 
         self.inner_radius = inner_radius
         self.hole = None
+        has_hole = hole_config[0]
         if has_hole:
-            self.hole = self._create_hole(depth)
+            hole_depth = hole_config[1]
+            self.hole = self._create_hole(hole_depth)
         self.outer_radius = outer_radius
 
         # visualisation
@@ -76,7 +78,7 @@ class Lake(ColorObstacle):
 
         color = tuple(config['color'])
 
-        return cls(pos, outer_radius, inner_radius, color, border_width, has_hole, depth)
+        return cls(pos, outer_radius, inner_radius, color, border_width, (has_hole, depth))
 
     def _create_points(self, scale) -> PointList:
         """

--- a/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
+++ b/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
@@ -39,8 +39,7 @@ class UltrasonicSensorBottom(BodyPart):
             if obstacle.collided_with(self.sprite.center_x, self.sprite.center_y):
                 if isinstance(obstacle, Hole):
                     return obstacle.depth
-                else:
-                    return self.get_default_value()
+                return self.get_default_value()
         return 20
 
     def get_default_value(self):

--- a/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
+++ b/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
@@ -8,6 +8,7 @@ from ev3dev2simulator.config.config import get_simulation_settings
 from ev3dev2simulator.robotpart.body_part import BodyPart
 from ev3dev2simulator.util.dimensions import Dimensions
 from ev3dev2simulator.obstacle.hole import Hole
+from ev3dev2simulator.obstacle.board import Board
 
 
 class UltrasonicSensorBottom(BodyPart):
@@ -39,8 +40,10 @@ class UltrasonicSensorBottom(BodyPart):
             if obstacle.collided_with(self.sprite.center_x, self.sprite.center_y):
                 if isinstance(obstacle, Hole):
                     return obstacle.depth
+                elif isinstance(obstacle, Board):
+                    return 20
                 return self.get_default_value()
-        return 20
+        return self.get_default_value()
 
     def get_default_value(self):
         """

--- a/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
+++ b/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
@@ -40,7 +40,7 @@ class UltrasonicSensorBottom(BodyPart):
             if obstacle.collided_with(self.sprite.center_x, self.sprite.center_y):
                 if isinstance(obstacle, Hole):
                     return obstacle.depth
-                elif isinstance(obstacle, Board):
+                if isinstance(obstacle, Board):
                     return 20
                 return self.get_default_value()
         return self.get_default_value()

--- a/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
+++ b/ev3dev2simulator/robotpart/ultrasonic_sensor_bottom.py
@@ -7,6 +7,7 @@ It represents an ultrasonic sensor that aims to the ground.
 from ev3dev2simulator.config.config import get_simulation_settings
 from ev3dev2simulator.robotpart.body_part import BodyPart
 from ev3dev2simulator.util.dimensions import Dimensions
+from ev3dev2simulator.obstacle.hole import Hole
 
 
 class UltrasonicSensorBottom(BodyPart):
@@ -36,7 +37,10 @@ class UltrasonicSensorBottom(BodyPart):
         """
         for obstacle in self.sensible_obstacles:
             if obstacle.collided_with(self.sprite.center_x, self.sprite.center_y):
-                return self.get_default_value()
+                if isinstance(obstacle, Hole):
+                    return obstacle.depth
+                else:
+                    return self.get_default_value()
         return 20
 
     def get_default_value(self):

--- a/ev3dev2simulator/robotpart/wheel.py
+++ b/ev3dev2simulator/robotpart/wheel.py
@@ -3,6 +3,7 @@ The wheel module contains the class Wheel which represents a wheel of an ev3dev2
 """
 
 from ev3dev2simulator.config.config import get_simulation_settings
+from ev3dev2simulator.obstacle.board import Board
 from ev3dev2simulator.robotpart.body_part import BodyPart
 from ev3dev2simulator.util.dimensions import Dimensions
 
@@ -28,9 +29,11 @@ class Wheel(BodyPart):
         """
         for obstacle in self.sensible_obstacles:
             if obstacle.collided_with(self.sprite.center_x, self.sprite.center_y):
+                if isinstance(obstacle, Board):
+                    return False
                 return True
 
         return self.get_default_value()
 
     def get_default_value(self):
-        return False
+        return True

--- a/ev3dev2simulator/state/world_state.py
+++ b/ev3dev2simulator/state/world_state.py
@@ -67,6 +67,7 @@ class WorldState:
             else:
                 print("unknown obstacle type")
 
+        self.falling_obstacles.append(board)
         self.color_obstacles.append(board)
 
         self.selected_object = None


### PR DESCRIPTION
The following commits add specific depths to obstacles. The depth of holes of lakes can be configured. The board, the playing field of the robots gets the height 20. Everything else sensed is assumed to be very deep. Previously, everything was assumed to be very shallow and specific obstacles had the maximum depth of 2550.